### PR TITLE
Fix how `summarize timers` handles running tests

### DIFF
--- a/bash_unit_tests/hey_test.sh
+++ b/bash_unit_tests/hey_test.sh
@@ -31,6 +31,17 @@ test_03_log_empty(){
 	no_content_output=$(XDG_DATA_HOME=$XDG_DATA_HOME $HEY_INVOCATION log 1 day)
 	assert_equals "No timers found" "$no_content_output"
 }
+test_03_1_summarize_timers_empty(){
+	no_content_output=$(XDG_DATA_HOME=$XDG_DATA_HOME $HEY_INVOCATION summarize timers 1 day)
+	assert_equals "No timers found" "$no_content_output"
+}
+test_03_2_summarize_timers_with_running_timer() {
+	XDG_DATA_HOME=$XDG_DATA_HOME $HEY_INVOCATION start @summarize-test > /dev/null
+	test_summary_output=$(XDG_DATA_HOME=$XDG_DATA_HOME $HEY_INVOCATION summarize timers 1 day)
+	rm -rf $XDG_DATA_HOME 2>&1 > /dev/null
+	assert_matches "summarize-test │         0s" "$test_summary_output"
+	assert_matches "Unaccounted…   │         0s" "$test_summary_output"
+}
 test_04_log-interrupts_empty(){
 	no_content_output=$(XDG_DATA_HOME=$XDG_DATA_HOME $HEY_INVOCATION log-interrupts 1 day)
 	assert_equals "No interruptions found" "$no_content_output"

--- a/lib/Hey/Timer.rakumod
+++ b/lib/Hey/Timer.rakumod
@@ -120,7 +120,7 @@ our sub display-timers-summary-as-table(@timer_hashes, $title) is export {
 	$table.add-row([("━" x $project_chars) , "━━━━━━━"]);
 	$table.add-row(['All…', concise(duration($total_seconds))]);
 	my $last_with_end =  @timer_hashes.grep({$_<ended_at> ~~ Int}).tail;
-	my $start_to_end = $last_with_end<ended_at>
+	my $start_to_end = $last_with_end<ended_at> ~~ Int:D
 		?? $last_with_end<ended_at> - @timer_hashes.head<started_at>
 		!! 0;
 	my $unaccounted_seconds = $start_to_end - $total_seconds;

--- a/lib/Hey/Timer.rakumod
+++ b/lib/Hey/Timer.rakumod
@@ -102,15 +102,16 @@ our sub display-timers-summary-as-table(@timer_hashes, $title) is export {
 	my $total_seconds = 0;
 	my %project_times = ();
 	for @timer_hashes -> %timer_hash {
-		if %timer_hash<ended_at> ~~ Int {
-			my $timer_seconds = (%timer_hash<ended_at> - %timer_hash<started_at>);
-			$total_seconds += $timer_seconds;
-			for %timer_hash<projects>.map({$_<name>}) -> $project {
-				%project_times.EXISTS-KEY($project)
-					?? (%project_times{$project} += $timer_seconds)
-					!! (%project_times{$project} = $timer_seconds);
-			}
-		}
+		# Running timers don't have an end-time; treat them as 0-length
+		my $timer_seconds = %timer_hash<ended_at> ~~ Int:D
+			?? (%timer_hash<ended_at> - %timer_hash<started_at>)
+			!! 0;
+		$total_seconds += $timer_seconds;
+		for %timer_hash<projects>.map({$_<name>}) -> $project {
+			%project_times.EXISTS-KEY($project)
+				?? (%project_times{$project} += $timer_seconds)
+				!! (%project_times{$project} = $timer_seconds);
+	    }
 	}
 	for %project_times.pairs.sort({.key}) -> $pair {
 		$table.add-row([$pair.key, concise(duration($pair.value))]);
@@ -120,7 +121,8 @@ our sub display-timers-summary-as-table(@timer_hashes, $title) is export {
 	$table.add-row(['All…', concise(duration($total_seconds))]);
 	my $last_with_end =  @timer_hashes.grep({$_<ended_at> ~~ Int}).tail;
 	my $start_to_end = $last_with_end<ended_at>
-						- @timer_hashes.head<started_at>;
+		?? $last_with_end<ended_at> - @timer_hashes.head<started_at>
+		!! 0;
 	my $unaccounted_seconds = $start_to_end - $total_seconds;
 	$table.add-row(['Unaccounted…', concise(duration($unaccounted_seconds))]);
 


### PR DESCRIPTION
The `summarize timers` command calculates the duration of all timers by subtracting the start time from the end time.  However, running timers do not have an end time and thus were incorrectly excluded from the summary.  Worse, if a user had 1 running time and no other timers, excluding the running timer would cause a runtime crash.

This PR updates the `summarize timers` command to treat running timers as 0 duration.  This provides more accurate output and avoids the runtime crash.

This PR also includes tests for the new `summarize timers` output.  I wasn't sure of the preferred naming convention for this repo; logically, these tests should be grouped after `test_03_log_empty`, but `test_04…` already exists.  I chose to number these as `test_03_1` and `test_03_2` rather than putting them at the end of the file or renumbering all following tests.