### PR TITLE
Remove `use lib 'lib'`

### DIFF
--- a/bin/hey
+++ b/bin/hey
@@ -27,7 +27,6 @@
 # - masukomi
 
 use v6;
-use lib 'lib';
 use DB::SQLite;
 use XDG::GuaranteedResources;
 use Listicles;


### PR DESCRIPTION
This is a (very) partial solution for #32 that speeds up `hey`'s startup time by 3.5% (about 30ms in my testing).  Not a huge win, but it's low-hanging fruit.

The change is to remove `use lib 'lib'` from `bin/hey`.  That use statement causes Rakudo to scan the `lib` directory for updated source code and thus interferes with using fully precompiled modules; for that reason (and due to minor security concerns), `use lib 'lib'` is generally [discouraged in production code](https://stackoverflow.com/a/66359963). (Though of course it's handy for development, when you _want_ to pick up changes to the source instead of use precompiled modules). 